### PR TITLE
fix: show workout tracker tab

### DIFF
--- a/script.js
+++ b/script.js
@@ -1011,7 +1011,8 @@ function App() {
 
 
     React.createElement(Section, { title: "Pick a Tool", right: /*#__PURE__*/React.createElement("span", { className: "text-xs text-slate-500" }, "Everything updates automatically") }, /*#__PURE__*/
-    React.createElement("div", { className: "grid grid-cols-4 gap-2" },
+    // Display all view tabs including Workout Tracker
+    React.createElement("div", { className: "grid grid-cols-5 gap-2" },
     VIEWS.map((v) => /*#__PURE__*/
     React.createElement("button", {
       key: v,


### PR DESCRIPTION
## Summary
- ensure the Workout Tracker tab appears by expanding grid layout to five columns

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a08936988322b8dbb1f3ad3c2ddb